### PR TITLE
Updating SSL protocol selection with fallback

### DIFF
--- a/etcd/client.py
+++ b/etcd/client.py
@@ -37,7 +37,7 @@ _SSL_CLIENT_KEY_FILEPATH = environ.get(
 
 
 class _SslHttpAdapter(HTTPAdapter):
-    """"Transport adapter" that allows us to use SSLv3."""
+    """"Transport adapter" for requests module that creates TLS connections."""
 
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(num_pools=connections,


### PR DESCRIPTION
- Running on Ubuntu 16.10 with Python 2.7.12+ running into issue selecting PROTOCOL_SSLv3
- Docs recommending using PROTOCOL_TLS
- Fallbacks provided for PROTOCOL_SSLv3 and PROTOCOL_SSLv23
    (PROTOCOL_TLS is alias for PROTOCOL_SSLv23)